### PR TITLE
Allow raw descriptions

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -105,7 +105,7 @@ class Document
         $node->appendChild($attribute);
     }
 
-    private function createElement($name, $value = null, $raw)
+    private function createElement($name, $value = null, $raw = false)
     {
         if (is_null($value)) {
             $element = $this->dom->createElement($name);

--- a/src/Document.php
+++ b/src/Document.php
@@ -74,8 +74,15 @@ class Document
                 continue;
             }
 
+            $raw = false;
+
+            if (substr($name, 0, 3) === 'RAW-') {
+                $name = ltrim($name, 'RAW-');
+                $raw  = true;
+            }
+
             $value   = $object->getElements()[$name];
-            $element = $this->createElement($name, $value);
+            $element = $this->createElement($name, $value, $raw);
 
             if ('display-name' === $name || 'long-description' === $name) {
                 $this->addAttribute($element, 'xml:lang', 'x-default');
@@ -98,7 +105,7 @@ class Document
         $node->appendChild($attribute);
     }
 
-    private function createElement($name, $value = null)
+    private function createElement($name, $value = null, $raw)
     {
         if (is_null($value)) {
             $element = $this->dom->createElement($name);
@@ -108,7 +115,7 @@ class Document
 
             $element->appendXML('<' . $name . '>' . $value . '</' . $name . '>');
         } else {
-            $element = $this->dom->createElement($name, Xml::escape($value));
+            $element = $this->dom->createElement($name, $raw ? $value : Xml::escape($value));
         }
 
         return $element;

--- a/src/Document.php
+++ b/src/Document.php
@@ -74,14 +74,15 @@ class Document
                 continue;
             }
 
-            $raw = false;
+            $raw   = false;
+            $value = $object->getElements()[$name];
 
-            if (substr($name, 0, 3) === 'RAW-') {
-                $name = ltrim($name, 'RAW-');
-                $raw  = true;
+            // If the value is an array then it contains the actual value and whether or not it should be escaped.
+            if (is_array($value)) {
+                $raw   = $value['raw'];
+                $value = $value['value'];
             }
 
-            $value   = $object->getElements()[$name];
             $element = $this->createElement($name, $value, $raw);
 
             if ('display-name' === $name || 'long-description' === $name) {

--- a/src/Product.php
+++ b/src/Product.php
@@ -45,9 +45,10 @@ class Product extends Base
      */
     public function setDescription($value, $raw = false)
     {
-        $key = ($raw ? 'RAW-' : '') . 'long-description';
-
-        $this->elements[$key] = $value;
+        $this->elements['long-description'] = [
+            'value' => $value,
+            'raw'   => $raw,
+        ];
     }
 
     /**

--- a/src/Product.php
+++ b/src/Product.php
@@ -38,12 +38,16 @@ class Product extends Base
 
     /**
      * Populates the description of the product/set/bundle in the <long-description xml:lang="x-default"> element
+     * @todo: Allow elements to be defined as raw or not and remove this hack.
      *
      * @param $value
+     * @param $raw
      */
-    public function setDescription($value)
+    public function setDescription($value, $raw = false)
     {
-        $this->elements['long-description'] = $value;
+        $key = ($raw ? 'RAW-' : '') . 'long-description';
+
+        $this->elements[$key] = $value;
     }
 
     /**

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -15,7 +15,7 @@ class ProductsTest extends AbstractTest
         foreach (['Product', 'Set', 'Bundle'] as $index => $example) {
             $element = new Product(strtoupper($example) . '123');
             $element->setName($example . ' number 123');
-            $element->setDescription('The description for an example ' . strtolower($example) . '!');
+            $element->setDescription('The description for an example ' . strtolower($example) . '! &amp;bull; Bullet Point', true);
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);

--- a/tests/fixtures/products.xml
+++ b/tests/fixtures/products.xml
@@ -5,7 +5,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Product number 123</display-name>
-    <long-description xml:lang="x-default">The description for an example product!</long-description>
+    <long-description xml:lang="x-default">The description for an example product! &amp;bull; Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -52,7 +52,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Set number 123</display-name>
-    <long-description xml:lang="x-default">The description for an example set!</long-description>
+    <long-description xml:lang="x-default">The description for an example set! &amp;bull; Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -92,7 +92,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Bundle number 123</display-name>
-    <long-description xml:lang="x-default">The description for an example bundle!</long-description>
+    <long-description xml:lang="x-default">The description for an example bundle! &amp;bull; Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>


### PR DESCRIPTION
This allows descriptions to be added completely unescaped. For now it's a hack, but longer term we need to allow this to be handled more elegantly.