### PR TITLE
Validate the element is a proper element before parsing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -114,6 +114,10 @@ class Parser
                 continue;
             }
 
+            if ($reader->nodeType !== XMLReader::ELEMENT) {
+                continue;
+            }
+
             $element = new SimpleXMLElement($reader->readOuterXML());
 
             switch ($nodeName) {


### PR DESCRIPTION
Fixes

```
PHP Fatal error:  Uncaught exception 'Exception' with message 'String could not be parsed as XML
```