### PR TITLE
Skip empty nodes when parsing XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ PHP library for working with Demandware XML files
 Helpers for working with Demandware XML files.
 
 - Exporting: supports category/product/variant/assignment files, and allows elements to be added in the order that makes sense for your code - they'll be exported in the sequence specified by the XSD automatically, and custom attribute elements are ordered by attribute ids for consistency between exports
-- Validating: against included XSD schemas (done automatically when exporting)
-- Parsing: *to-do*
+- Validating: against included XSD schemas (done automatically when exporting) but only for files up to 1Gb
+- Parsing: simple methods to retrieve category/assignment/product/variation/set/bundle arrays from an XML file, mapping ids to the more useful elements and, optionally, attributes
 - Comparing: *in-progress* reports on different ids/elements/attributes, regardless of how they're ordered in the files (i.e. higher-level than diff) which is useful when different systems/processes have exported the files
 
 
@@ -18,10 +18,19 @@ Via Composer:
 $ composer require fusionspim/php-demandware-xml
 ```
 
+
 Usage
 ---
 
 To run the tests run `php vendor/bin/phpunit` from the project directory. Look in `tests/fixtures` for output examples.
+
+
+Benchmarks
+---
+
+Very crude figures, but a 2015 Macbook takes approximately:
+
+- 40s to parse 105Mb categories file
 
 
 Future plans

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -120,6 +120,8 @@ class Parser
 
             $xml = trim($reader->readOuterXML());
 
+            // handle xml with empty lines between elements `</product>\n\n</product>` instead of `</product>\n</product>`
+            // i.e. more than a line-break so we get an empty node :-/
             if (0 === strlen($xml)) {
                 continue;
             }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -118,7 +118,13 @@ class Parser
                 continue;
             }
 
-            $element = new SimpleXMLElement($reader->readOuterXML());
+            $xml = trim($reader->readOuterXML());
+
+            if (0 === strlen($xml)) {
+                continue;
+            }
+
+            $element = new SimpleXMLElement($xml);
 
             switch ($nodeName) {
                 case 'category':


### PR DESCRIPTION
Fixes 'String could not be parsed as XML' exceptions thrown by `SimpleXMLElement->__construct('')`.