### PR TITLE
Bug parsing booleans

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -268,7 +268,7 @@ class Parser
 
                 // cast strings to booleans (only needed for single values, as multi-value booleans make no sense)
                 if ('true' === $value || 'false' === $value) {
-                    $value = (boolean) $value;
+                    $value = ('true' === $value);
                 }
             }
 

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -34,7 +34,8 @@ class ProductsTest extends AbstractTest
                 'zzz'          => 'Should be exported last within custom-attributes',
                 'primaryImage' => strtolower($example) . '-123.png',
                 'multiWow'     => ['so', 'such', 'many', 'much', 'very'],
-                'boolTest'     => true
+                'boolTrue'     => true,
+                'boolFalse'    => false
             ]);
             // elements/attributes specific to bundle/set/product
             if ('Bundle' === $example) {

--- a/tests/fixtures/bundles.json
+++ b/tests/fixtures/bundles.json
@@ -1,7 +1,8 @@
 {
     "BUNDLE123": {
         "attributes": {
-            "boolTest": true,
+            "boolFalse": false,
+            "boolTrue": true,
             "multiWow": [
                 "so",
                 "such",

--- a/tests/fixtures/invalid_products.xml
+++ b/tests/fixtures/invalid_products.xml
@@ -22,7 +22,8 @@
             <page-url xml:lang="x-default">http://example.com/product/123</page-url>
         </page-attributes>
         <custom-attributes>
-            <custom-attribute attribute-id="boolTest">true</custom-attribute>
+            <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+            <custom-attribute attribute-id="boolTrue">true</custom-attribute>
             <custom-attribute attribute-id="multiWow">
                 <value>so</value>
                 <value>such</value>
@@ -69,7 +70,8 @@
             <page-url xml:lang="x-default">http://example.com/set/123</page-url>
         </page-attributes>
         <custom-attributes>
-            <custom-attribute attribute-id="boolTest">true</custom-attribute>
+            <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+            <custom-attribute attribute-id="boolTrue">true</custom-attribute>
             <custom-attribute attribute-id="multiWow">
                 <value>so</value>
                 <value>such</value>
@@ -110,7 +112,8 @@
             <page-url xml:lang="x-default">http://example.com/bundle/123</page-url>
         </page-attributes>
         <custom-attributes>
-            <custom-attribute attribute-id="boolTest">true</custom-attribute>
+            <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+            <custom-attribute attribute-id="boolTrue">true</custom-attribute>
             <custom-attribute attribute-id="multiWow">
                 <value>so</value>
                 <value>such</value>

--- a/tests/fixtures/products.json
+++ b/tests/fixtures/products.json
@@ -1,7 +1,8 @@
 {
     "PRODUCT123": {
         "attributes": {
-            "boolTest": true,
+            "boolFalse": false,
+            "boolTrue": true,
             "multiWow": [
                 "so",
                 "such",

--- a/tests/fixtures/products.xml
+++ b/tests/fixtures/products.xml
@@ -22,7 +22,8 @@
       <page-url xml:lang="x-default">http://example.com/product/123</page-url>
     </page-attributes>
     <custom-attributes>
-      <custom-attribute attribute-id="boolTest">true</custom-attribute>
+      <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+      <custom-attribute attribute-id="boolTrue">true</custom-attribute>
       <custom-attribute attribute-id="multiWow">
         <value>so</value>
         <value>such</value>
@@ -69,7 +70,8 @@
       <page-url xml:lang="x-default">http://example.com/set/123</page-url>
     </page-attributes>
     <custom-attributes>
-      <custom-attribute attribute-id="boolTest">true</custom-attribute>
+      <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+      <custom-attribute attribute-id="boolTrue">true</custom-attribute>
       <custom-attribute attribute-id="multiWow">
         <value>so</value>
         <value>such</value>
@@ -110,7 +112,8 @@
       <page-url xml:lang="x-default">http://example.com/bundle/123</page-url>
     </page-attributes>
     <custom-attributes>
-      <custom-attribute attribute-id="boolTest">true</custom-attribute>
+      <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+      <custom-attribute attribute-id="boolTrue">true</custom-attribute>
       <custom-attribute attribute-id="multiWow">
         <value>so</value>
         <value>such</value>
@@ -154,7 +157,8 @@
       <page-url xml:lang="x-default">http://example.com/variation/123</page-url>
     </page-attributes>
     <custom-attributes>
-      <custom-attribute attribute-id="boolTest">true</custom-attribute>
+      <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+      <custom-attribute attribute-id="boolTrue">true</custom-attribute>
       <custom-attribute attribute-id="multiWow">
         <value>so</value>
         <value>such</value>

--- a/tests/fixtures/sets.json
+++ b/tests/fixtures/sets.json
@@ -1,7 +1,8 @@
 {
     "SET123": {
         "attributes": {
-            "boolTest": true,
+            "boolFalse": false,
+            "boolTrue": true,
             "multiWow": [
                 "so",
                 "such",

--- a/tests/fixtures/variations.json
+++ b/tests/fixtures/variations.json
@@ -1,7 +1,8 @@
 {
     "VARIATION123": {
         "attributes": {
-            "boolTest": true,
+            "boolFalse": false,
+            "boolTrue": true,
             "multiWow": [
                 "so",
                 "such",


### PR DESCRIPTION
When parsing attribute values, ‘true’ was being correctly converted to a boolean, but ‘false’ wasn’t. Fixed that and improved tests.