### PR TITLE
Hotfix: XML entity encoding

### DIFF
--- a/src/Product.php
+++ b/src/Product.php
@@ -37,7 +37,8 @@ class Product extends Base
     }
 
     /**
-     * Populates the description of the product/set/bundle in the <long-description xml:lang="x-default"> element
+     * Populates the description of the product/set/bundle in the <long-description xml:lang="x-default"> element.
+     * Accepts text and unencoded HTML (which will be encoded as UTF-8 entities).
      * @todo: Allow elements to be defined as raw or not and remove this hack.
      *
      * @param $value

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -7,7 +7,8 @@ use \DemandwareXml\XmlException;
 class Xml
 {
     /**
-     * Escapes the value suitable for inclusion in XML and converts booleans to 'true'/'false' strings
+     * Escapes the value suitable for inclusion in XML and converts booleans to 'true'/'false' strings.
+     * Accepts text and unencoded HTML (which will be encoded as UTF-8 entities).
      *
      * @param $value
      * @return string
@@ -17,8 +18,6 @@ class Xml
         if (is_bool($value)) {
             return ($value ? 'true' : 'false');
         } else {
-            $value = html_entity_decode($value); // not sure why, other than back compat
-
             return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
         }
     }

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -78,7 +78,7 @@ class ProductsTest extends AbstractTest
     public function testProductsInvalidEntitiesException()
     {
         $element = new Product('product123');
-        $element->setName('product number 123 &amp;bull;');
+        $element->setName('product number 123 &bull;');
 
         $this->document->addObject($element);
         $this->document->save(__DIR__ . '/output/products.xml');

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -15,7 +15,7 @@ class ProductsTest extends AbstractTest
         foreach (['Product', 'Set', 'Bundle', 'Variation'] as $index => $example) {
             $element = new Product(strtoupper($example) . '123');
             $element->setName($example . ' number 123');
-            $element->setDescription('The description for an <i>example</i> ' . strtolower($example) . '! &amp;bull; Bullet Point', true);
+            $element->setDescription('The description for an <i>example</i> ' . strtolower($example) . '! • Bullet Point', true);
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);

--- a/tests/fixtures/invalid_products.xml
+++ b/tests/fixtures/invalid_products.xml
@@ -5,7 +5,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Product number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example product! &amp;bull; Bullet Point & this is broken</long-description>
+        <long-description xml:lang="x-default">The description for an example product! • Bullet Point & this is broken</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>
@@ -53,7 +53,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Set number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example set! &amp;bull; Bullet Point</long-description>
+        <long-description xml:lang="x-default">The description for an example set! • Bullet Point</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>
@@ -94,7 +94,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Bundle number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example bundle! &amp;bull; Bullet Point</long-description>
+        <long-description xml:lang="x-default">The description for an example bundle! • Bullet Point</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>

--- a/tests/fixtures/invalid_products.xml
+++ b/tests/fixtures/invalid_products.xml
@@ -5,7 +5,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Product number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example product! • Bullet Point & this is broken</long-description>
+        <long-description xml:lang="x-default">The description for an example product! &amp;bull; Bullet Point & this is broken</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>
@@ -53,7 +53,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Set number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example set! • Bullet Point</long-description>
+        <long-description xml:lang="x-default">The description for an example set! &amp;bull; Bullet Point</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>
@@ -94,7 +94,7 @@
         <min-order-quantity>1</min-order-quantity>
         <step-quantity>1</step-quantity>
         <display-name xml:lang="x-default">Bundle number 123</display-name>
-        <long-description xml:lang="x-default">The description for an example bundle! • Bullet Point</long-description>
+        <long-description xml:lang="x-default">The description for an example bundle! &amp;bull; Bullet Point</long-description>
         <online-flag>true</online-flag>
         <online-from>2015-01-23T01:23:45</online-from>
         <online-to>2025-01-23T01:23:45</online-to>

--- a/tests/fixtures/products.xml
+++ b/tests/fixtures/products.xml
@@ -5,7 +5,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Product number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; product! &amp;bull; Bullet Point</long-description>
+    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; product! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -53,7 +53,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Set number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; set! &amp;bull; Bullet Point</long-description>
+    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; set! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -94,7 +94,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Bundle number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; bundle! &amp;bull; Bullet Point</long-description>
+    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; bundle! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -140,7 +140,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Variation number 123</display-name>
-    <long-description xml:lang="x-default">The description for an example variation! &amp;bull; Bullet Point</long-description>
+    <long-description xml:lang="x-default">The description for an example variation! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>


### PR DESCRIPTION
Accept text and unencoded HTML (which will be encoded as UTF-8 entities).