### PR TITLE
Fix casting strings to bools

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -234,7 +234,7 @@ class Parser
         // if they exist, online/searchable will always be a true/false string, so cast for ease of use
         foreach (['online', 'searchable'] as $name) {
             if (isset($details[$name])) {
-                $details[$name] = (boolean) $details[$name];
+                $details[$name] = filter_var($details[$name], FILTER_VALIDATE_BOOLEAN);
             }
         }
 

--- a/tests/fixtures/bundles-simple.json
+++ b/tests/fixtures/bundles-simple.json
@@ -4,7 +4,7 @@
         "description": "The description for an <i>example<\/i> bundle! \u2022 Bullet Point",
         "name": "Bundle number 123",
         "online": true,
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "tax": 20,
         "variations": {

--- a/tests/fixtures/bundles.json
+++ b/tests/fixtures/bundles.json
@@ -24,7 +24,7 @@
             "keywords": "Bundle, test, example",
             "url": "http:\/\/example.com\/bundle\/123"
         },
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "tax": 20,
         "variations": {

--- a/tests/fixtures/products-simple.json
+++ b/tests/fixtures/products-simple.json
@@ -4,7 +4,7 @@
         "description": "The description for an <i>example<\/i> product! \u2022 Bullet Point",
         "name": "Product number 123",
         "online": true,
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "variations": {
             "SKU0000001": false,

--- a/tests/fixtures/products.json
+++ b/tests/fixtures/products.json
@@ -24,7 +24,7 @@
             "keywords": "Product, test, example",
             "url": "http:\/\/example.com\/product\/123"
         },
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "variations": {
             "SKU0000001": false,

--- a/tests/fixtures/sets-simple.json
+++ b/tests/fixtures/sets-simple.json
@@ -4,7 +4,7 @@
         "description": "The description for an <i>example<\/i> set! \u2022 Bullet Point",
         "name": "Set number 123",
         "online": true,
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "products": [
             "PRODUCT123",

--- a/tests/fixtures/sets.json
+++ b/tests/fixtures/sets.json
@@ -24,7 +24,7 @@
             "keywords": "Set, test, example",
             "url": "http:\/\/example.com\/set\/123"
         },
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45",
         "products": [
             "PRODUCT123",

--- a/tests/fixtures/variations-simple.json
+++ b/tests/fixtures/variations-simple.json
@@ -3,7 +3,7 @@
         "description": "The description for an example variation! \u2022 Bullet Point",
         "name": "Variation number 123",
         "online": true,
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45"
     }
 }

--- a/tests/fixtures/variations.json
+++ b/tests/fixtures/variations.json
@@ -23,7 +23,7 @@
             "keywords": "Variation, test, example",
             "url": "http:\/\/example.com\/variation\/123"
         },
-        "searchable": true,
+        "searchable": false,
         "start": "2015-01-23T01:23:45"
     }
 }


### PR DESCRIPTION
Casting "false" to bool is always true, use filter_var instead