### PR TITLE
Fix Long Description Escaping Issues

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -111,10 +111,10 @@ class Document
         if (is_null($value)) {
             $element = $this->dom->createElement($name);
         } elseif ('long-description' !== $name && strlen($value) > 0 && '<' === $value[0]) {
-            // Skip long descriptions, as they should always be escaped.
-            // This is terrible, but if first char looks like is xml, just append the fragment.
+            // Skip long descriptions as they should always be inserted as elements and escaped.
+            // This is terrible, but if first char looks like it's XML then just append the fragment.
+            // This is to append pre-built XML from objects.
             $element = $this->dom->createDocumentFragment();
-
             $element->appendXML('<' . $name . '>' . $value . '</' . $name . '>');
         } else {
             $element = $this->dom->createElement($name, ($raw ? $value : Xml::escape($value)));

--- a/src/Document.php
+++ b/src/Document.php
@@ -110,13 +110,14 @@ class Document
     {
         if (is_null($value)) {
             $element = $this->dom->createElement($name);
-        } elseif (strlen($value) > 0 && '<' === $value[0]) {
-            // this is terrible, but if first char looks like is xml, just append the fragment
+        } elseif ('long-description' !== $name && strlen($value) > 0 && '<' === $value[0]) {
+            // Skip long descriptions, as they should always be escaped.
+            // This is terrible, but if first char looks like is xml, just append the fragment.
             $element = $this->dom->createDocumentFragment();
 
             $element->appendXML('<' . $name . '>' . $value . '</' . $name . '>');
         } else {
-            $element = $this->dom->createElement($name, $raw ? $value : Xml::escape($value));
+            $element = $this->dom->createElement($name, ($raw ? $value : Xml::escape($value)));
         }
 
         return $element;

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -66,9 +66,9 @@ class ProductsTest extends AbstractTest
     public function testProductsXml()
     {
         $sampleXml = $this->loadFixture('products.xml');
-        $outputXml = $this->document->getDomDocument();
+        $outputXml = $this->document->getDomDocument()->saveXML();
 
-        $this->assertEqualXMLStructure($sampleXml->firstChild, $outputXml->firstChild);
+        $this->assertXmlStringEqualsXmlString($sampleXml, $outputXml);
     }
 
     /**

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -15,7 +15,7 @@ class ProductsTest extends AbstractTest
         foreach (['Product', 'Set', 'Bundle', 'Variation'] as $index => $example) {
             $element = new Product(strtoupper($example) . '123');
             $element->setName($example . ' number 123');
-            $element->setDescription('The description for an <i>example</i> ' . strtolower($example) . '! • Bullet Point', true);
+            $element->setDescription('<b>' . $example . '</b> The description for an <i>example</i> ' . strtolower($example) . '! • Bullet Point', true);
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);

--- a/tests/fixtures/bundles-simple.json
+++ b/tests/fixtures/bundles-simple.json
@@ -2,7 +2,7 @@
     "BUNDLE123": {
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> bundle! \u2022 Bullet Point",
+        "description": "<b>Bundle<\/b> The description for an <i>example<\/i> bundle! \u2022 Bullet Point",
         "name": "Bundle number 123",
         "online": true,
         "searchable": false,

--- a/tests/fixtures/bundles.json
+++ b/tests/fixtures/bundles.json
@@ -16,7 +16,7 @@
         },
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> bundle! \u2022 Bullet Point",
+        "description": "<b>Bundle<\/b> The description for an <i>example<\/i> bundle! \u2022 Bullet Point",
         "name": "Bundle number 123",
         "online": true,
         "page": {

--- a/tests/fixtures/products-simple.json
+++ b/tests/fixtures/products-simple.json
@@ -2,7 +2,7 @@
     "PRODUCT123": {
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> product! \u2022 Bullet Point",
+        "description": "<b>Product<\/b> The description for an <i>example<\/i> product! \u2022 Bullet Point",
         "name": "Product number 123",
         "online": true,
         "searchable": false,

--- a/tests/fixtures/products.json
+++ b/tests/fixtures/products.json
@@ -16,7 +16,7 @@
         },
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> product! \u2022 Bullet Point",
+        "description": "<b>Product<\/b> The description for an <i>example<\/i> product! \u2022 Bullet Point",
         "name": "Product number 123",
         "online": true,
         "page": {

--- a/tests/fixtures/products.xml
+++ b/tests/fixtures/products.xml
@@ -5,7 +5,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Product number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; product! • Bullet Point</long-description>
+    <long-description xml:lang="x-default">&lt;b&gt;Product&lt;/b&gt; The description for an &lt;i&gt;example&lt;/i&gt; product! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -53,7 +53,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Set number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; set! • Bullet Point</long-description>
+    <long-description xml:lang="x-default">&lt;b&gt;Set&lt;/b&gt; The description for an &lt;i&gt;example&lt;/i&gt; set! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -94,7 +94,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Bundle number 123</display-name>
-    <long-description xml:lang="x-default">The description for an &lt;i&gt;example&lt;/i&gt; bundle! • Bullet Point</long-description>
+    <long-description xml:lang="x-default">&lt;b&gt;Bundle&lt;/b&gt; The description for an &lt;i&gt;example&lt;/i&gt; bundle! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>
@@ -140,7 +140,7 @@
     <min-order-quantity>1</min-order-quantity>
     <step-quantity>1</step-quantity>
     <display-name xml:lang="x-default">Variation number 123</display-name>
-    <long-description xml:lang="x-default">The description for an example variation! • Bullet Point</long-description>
+    <long-description xml:lang="x-default">&lt;b&gt;Variation&lt;/b&gt; The description for an &lt;i&gt;example&lt;/i&gt; variation! • Bullet Point</long-description>
     <online-flag>true</online-flag>
     <online-from>2015-01-23T01:23:45</online-from>
     <online-to>2025-01-23T01:23:45</online-to>

--- a/tests/fixtures/sets-simple.json
+++ b/tests/fixtures/sets-simple.json
@@ -2,7 +2,7 @@
     "SET123": {
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> set! \u2022 Bullet Point",
+        "description": "<b>Set<\/b> The description for an <i>example<\/i> set! \u2022 Bullet Point",
         "name": "Set number 123",
         "online": true,
         "searchable": false,

--- a/tests/fixtures/sets.json
+++ b/tests/fixtures/sets.json
@@ -16,7 +16,7 @@
         },
         "brand": "SampleBrand™",
         "classification": "CAT123",
-        "description": "The description for an <i>example<\/i> set! \u2022 Bullet Point",
+        "description": "<b>Set<\/b> The description for an <i>example<\/i> set! \u2022 Bullet Point",
         "name": "Set number 123",
         "online": true,
         "page": {

--- a/tests/fixtures/variations-simple.json
+++ b/tests/fixtures/variations-simple.json
@@ -1,7 +1,7 @@
 {
     "VARIATION123": {
         "brand": "SampleBrand™",
-        "description": "The description for an example variation! \u2022 Bullet Point",
+        "description": "<b>Variation<\/b> The description for an <i>example<\/i> variation! \u2022 Bullet Point",
         "name": "Variation number 123",
         "online": true,
         "searchable": false,

--- a/tests/fixtures/variations.json
+++ b/tests/fixtures/variations.json
@@ -15,7 +15,7 @@
             "zzz": "Should be exported last within custom-attributes"
         },
         "brand": "SampleBrand™",
-        "description": "The description for an example variation! \u2022 Bullet Point",
+        "description": "<b>Variation<\/b> The description for an <i>example</i> variation! \u2022 Bullet Point",
         "name": "Variation number 123",
         "online": true,
         "page": {


### PR DESCRIPTION
Long descriptions that start with HTML tags get treated as internal XML fragments and inserted raw. This fix ensures they’re always inserted as elements and the appropriate escaping is applied. 

I've also updated the tests so the whole XML is compared against the fixtures, previously only the structure was being compared, allowing content errors to slip though.