### PR TITLE
Sanitise Invalid XML Characters

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -116,7 +116,8 @@ class Document
 
             $element->appendXML('<' . $name . '>' . $value . '</' . $name . '>');
         } else {
-            $element = $this->dom->createElement($name, $raw ? $value : Xml::escape($value));
+            $value   = ($raw ? Xml::sanitise($value) : Xml::escape($value));
+            $element = $this->dom->createElement($name, $value);
         }
 
         return $element;

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -28,13 +28,14 @@ class Xml
     /**
      * Sanitise a string for XML.
      *
-     * @link    http://www.phpwact.org/php/i18n/charsets#common_problem_areas_with_utf-8
+     * @link   http://www.phpwact.org/php/i18n/charsets#common_problem_areas_with_utf-8
+     * @link   http://www.xiven.com/weblog/2013/08/30/PHPInvalidUTF8InXMLRevisited
      * @param  $string
      * @return string
      */
     public static function sanitise($string)
     {
-        return preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $string);
+        return preg_replace('/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', ' ', $string);
     }
 
     /**

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -35,7 +35,7 @@ class Xml
      */
     public static function sanitise($string)
     {
-        return preg_replace('/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', ' ', $string);
+        return preg_replace('/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u', ' ', $string);
     }
 
     /**

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -18,8 +18,23 @@ class Xml
         if (is_bool($value)) {
             return ($value ? 'true' : 'false');
         } else {
-            return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+            $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+            $value = static::sanitise($value);
+
+            return $value;
         }
+    }
+
+    /**
+     * Sanitise a string for XML.
+     *
+     * @link    http://www.phpwact.org/php/i18n/charsets#common_problem_areas_with_utf-8
+     * @param  $string
+     * @return string
+     */
+    public static function sanitise($string)
+    {
+        return preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $string);
     }
 
     /**

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -15,7 +15,7 @@ class ProductsTest extends AbstractTest
         foreach (['Product', 'Set', 'Bundle', 'Variation'] as $index => $example) {
             $element = new Product(strtoupper($example) . '123');
             $element->setName($example . ' number 123');
-            $element->setDescription('<b>' . $example . '</b> The description for an <i>example</i> ' . strtolower($example) . '! • Bullet Point', true);
+            $element->setDescription('<b>' . $example . '</b> The description for an <i>example</i> ' . strtolower($example) . '! • BulletPoint', true);
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -10,12 +10,14 @@ class ProductsTest extends AbstractTest
 
     public function setUp()
     {
+        $invalidChar = ''; // Record Separator.
+
         $document = new Document('TestCatalog');
 
         foreach (['Product', 'Set', 'Bundle', 'Variation'] as $index => $example) {
             $element = new Product(strtoupper($example) . '123');
             $element->setName($example . ' number 123');
-            $element->setDescription('<b>' . $example . '</b> The description for an <i>example</i> ' . strtolower($example) . '! • BulletPoint', true);
+            $element->setDescription('<b>' . $example . '</b> The description for an <i>example</i> ' . strtolower($example) . '! • Bullet' . $invalidChar . 'Point', true);
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -11,7 +11,7 @@ class XmlTest extends PHPUnit_Framework_TestCase
     {
         $invalidChar = ''; // Record Separator.
 
-        $this->assertEquals('Blah Blah', Xml::sanitise('Blah' . $invalidChar . 'Blah'));
+        $this->assertEquals('Foo Bar', Xml::sanitise('Foo' . $invalidChar . 'Bar'));
     }
 
     public function testValidateXml()

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -9,7 +9,9 @@ class XmlTest extends PHPUnit_Framework_TestCase
 {
     public function testSanitise()
     {
-        $this->assertEquals('Blah Blah', Xml::sanitise('BlahBlah'));
+        $invalidChar = ''; // Record Separator.
+
+        $this->assertEquals('Blah Blah', Xml::sanitise('Blah' . $invalidChar . 'Blah'));
     }
 
     public function testValidateXml()

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -7,6 +7,11 @@ use \DemandwareXml\XmlException;
 
 class XmlTest extends PHPUnit_Framework_TestCase
 {
+    public function testSanitise()
+    {
+        $this->assertEquals('Blah Blah', Xml::sanitise('BlahBlah'));
+    }
+
     public function testValidateXml()
     {
         $xmlPath = __DIR__ . '/fixtures/products.xml';


### PR DESCRIPTION
- Added new `sanitise()` method that removes invalid XML characters (e.g. record separator).
- Invalid characters are replaced with a single space.
- Updated `escape()` to sanitise automatically.
- Ensured raw `long-description` value gets sanitised.
- Updated unit tests to include invalid character.

```PHP Warning:  DOMNode::appendChild(): Document Fragment is empty in php-demandware-xml/src/Document.php on line 95```