### PR TITLE
Fix for assignments test data

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -152,7 +152,7 @@ class Parser
     {
         $productId  = (string) $element['product-id'];
         $categoryId = (string) $element['category-id'];
-        $primary    = (isset($element->{'primary-flag'}) ? (boolean) $element->{'primary-flag'} : false);
+        $primary    = (isset($element->{'primary-flag'}) ? ((string) $element->{'primary-flag'}) === 'true': false);
 
         $this->assignments[$productId][] = [$categoryId => $primary];
     }

--- a/tests/CategoriesTest.php
+++ b/tests/CategoriesTest.php
@@ -37,26 +37,27 @@ class CategoriesTest extends AbstractTest
     {
         $document = new Document('TestCatalog');
 
-        foreach (['PROD1' => ['CAT1', 'CAT2'], 'PROD2' => ['CAT1'], 'PROD3' => ['CAT3']] as $product => $categories) {
-            foreach ($categories as $category) {
-                // simulate some application logic
-                $primary = ('PROD1' === $product && 'CAT2' === $category);
-                $deleted = ('PROD2' === $product && 'CAT1' === $category);
-                $element = new Assignment($product, $category);
-                // flag as deleted if app logic says so, otherwise handle primary flag...
-                if ($deleted) {
-                    $element->setDeleted();
-                } else {
-                    $element->setPrimary($primary);
-                }
-                $document->addObject($element);
-                // simulate some more application logic, put all primary products in CAT42
-                if ($primary) {
-                    $element = new Assignment($product, 'CAT42');
-                    $document->addObject($element);
-                }
-            }
-        }
+        // PROD1 has a primary assignment, non-primary, and unspecified
+        $element = new Assignment('PROD1', 'CAT1');
+        $element->setPrimary(false);
+        $document->addObject($element);
+
+        $element = new Assignment('PROD1', 'CAT2');
+        $element->setPrimary(true);
+        $document->addObject($element);
+
+        $element = new Assignment('PROD1', 'CAT42');
+        $document->addObject($element);
+
+        // PROD2 has a deleted assignment
+        $element = new Assignment('PROD2', 'CAT1');
+        $element->setDeleted();
+        $document->addObject($element);
+
+        // PROD3 has a primary assignment
+        $element = new Assignment('PROD3', 'CAT3');
+        $element->setPrimary(false);
+        $document->addObject($element);
 
         $sampleXml = $this->loadFixture('assignments.xml');
         $outputXml = $document->getDomDocument();

--- a/tests/CategoriesTest.php
+++ b/tests/CategoriesTest.php
@@ -37,22 +37,24 @@ class CategoriesTest extends AbstractTest
     {
         $document = new Document('TestCatalog');
 
-        foreach (['PROD1' => 'CAT1', 'PROD1' => 'CAT2', 'PROD2' => 'CAT1', 'PROD3' => 'CAT3'] as $product => $category) {
-            // simulate some application logic
-            $primary = ('PROD1' === $product && 'CAT2' === $category);
-            $deleted = ('PROD2' === $product && 'CAT1' === $category);
-            $element = new Assignment($product, $category);
-            // flag as deleted if app logic says so, otherwise handle primary flag...
-            if ($deleted) {
-                $element->setDeleted();
-            } else {
-                $element->setPrimary($primary);
-            }
-            $document->addObject($element);
-            // simulate some more application logic, put all primary products in CAT42
-            if ($primary) {
-                $element = new Assignment($product, 'CAT42');
+        foreach (['PROD1' => ['CAT1', 'CAT2'], 'PROD2' => ['CAT1'], 'PROD3' => ['CAT3']] as $product => $categories) {
+            foreach ($categories as $category) {
+                // simulate some application logic
+                $primary = ('PROD1' === $product && 'CAT2' === $category);
+                $deleted = ('PROD2' === $product && 'CAT1' === $category);
+                $element = new Assignment($product, $category);
+                // flag as deleted if app logic says so, otherwise handle primary flag...
+                if ($deleted) {
+                    $element->setDeleted();
+                } else {
+                    $element->setPrimary($primary);
+                }
                 $document->addObject($element);
+                // simulate some more application logic, put all primary products in CAT42
+                if ($primary) {
+                    $element = new Assignment($product, 'CAT42');
+                    $document->addObject($element);
+                }
             }
         }
 

--- a/tests/fixtures/assignments.json
+++ b/tests/fixtures/assignments.json
@@ -1,6 +1,9 @@
 {
     "PROD1": [
         {
+            "CAT1": false
+        },
+        {
             "CAT2": true
         },
         {

--- a/tests/fixtures/assignments.json
+++ b/tests/fixtures/assignments.json
@@ -17,7 +17,7 @@
     ],
     "PROD3": [
         {
-            "CAT3": true
+            "CAT3": false
         }
     ]
 }

--- a/tests/fixtures/assignments.xml
+++ b/tests/fixtures/assignments.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="TestCatalog">
+  <category-assignment product-id="PROD1" category-id="CAT1">
+    <primary-flag>false</primary-flag>
+  </category-assignment>
   <category-assignment product-id="PROD1" category-id="CAT2">
     <primary-flag>true</primary-flag>
   </category-assignment>


### PR DESCRIPTION
Noticed that `PROD1` was supposed to have two assignments, but the test array was structured such that `CAT1` assignment would be lost.

Have fixed this, but getting an error with `testAssignmentsParser()` now and can’t spot the issue - halp!