### PR TITLE
Allow null values for start date, sitemap priority and page attributes

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -39,7 +39,7 @@ abstract class Base
     /**
      * Populates <online-from> and <online-to> dates in Demandware format, if provided
      */
-    public function setDates(string $from, string $to = null)
+    public function setDates(string $from = null, string $to = null)
     {
         if (! $this->isEmptyDate($from)) {
             $this->elements['online-from'] = str_replace(' ', 'T', $from);
@@ -61,7 +61,7 @@ abstract class Base
      *
      * @throws XmlException
      */
-    public function setSitemap(float $priority = 0.5, bool $included = true, string $frequency = 'weekly')
+    public function setSitemap(float $priority = null, bool $included = true, string $frequency = 'weekly')
     {
         if ($priority > 1) {
             throw new XmlException('Sitemap priority must be 1.0 or less');
@@ -83,7 +83,7 @@ abstract class Base
     /**
      * Populates <page-attributes> child elements, all of which will be given a `xml:lang="x-default"` attribute
      */
-    public function setPageAttributes(string $title, string $description, string $keywords, string $url)
+    public function setPageAttributes(string $title = null, string $description = null, string $keywords = null, string $url = null)
     {
         $elements = [
             'page-title'       => $title,

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -21,7 +21,7 @@ class ProductsTest extends AbstractTest
             $element->setUpc('50000000000' . $index);
             $element->setQuantities(); // include, but use defaults
             $element->setRank(1);
-            $element->setSitemap(); // include, but use defaults
+            $element->setSitemap(0.5);
             $element->setBrand('SampleBrand™');
             $element->setFlags(true, false);
             $element->setDates('2015-01-23 01:23:45', '2025-01-23 01:23:45');


### PR DESCRIPTION
These changes are as a result of trying to integrate PHP Demandware XML 2.0 into Fusions, which was failing some tests.