### PR TITLE
Improve and spruce up test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 out
 vendor
 tests/output/*
+tests/coverage/*
 .gitkeep
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "psr-4": { "DemandwareXml\\": "src" }
   },
   "autoload-dev": {
-    "psr-4": { "DemandwareXml\\Test\\": "test" }
+    "psr-4": { "DemandwareXml\\Test\\": "tests" }
   }
 }

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -31,6 +31,7 @@ class Xml
      */
     public static function sanitise(string $string): string
     {
+        // Only allow Tab (9), LF (10), CR (13), Space (32) - 55295, 57344 - 65533, 65536 - 1114111.
         return preg_replace('/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u', ' ', $string);
     }
 

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -1,7 +1,6 @@
 <?php
 namespace DemandwareXml;
 
-use DemandwareXml\XmlException;
 use DOMDocument;
 
 class Xml

--- a/tests/CategoriesTest.php
+++ b/tests/CategoriesTest.php
@@ -2,9 +2,12 @@
 namespace DemandwareXml\Test;
 
 use DemandwareXml\{Assignment, Category, Document};
+use PHPUnit\Framework\TestCase;
 
-class CategoriesTest extends AbstractTest
+class CategoriesTest extends TestCase
 {
+    use FixtureHelper;
+
     public function testCategoriesXml()
     {
         $document = new Document('TestCatalog');

--- a/tests/CategoriesTest.php
+++ b/tests/CategoriesTest.php
@@ -17,6 +17,7 @@ class CategoriesTest extends AbstractTest
             $element->setFlags(true);
             $element->setSitemap(0.2);
             $element->setPageAttributes($example, 'Buy ' . $example, strtolower($example), '/' . $example);
+            $element->setDates('2018-01-01 01:01:01', '2018-02-02 02:02:02');
             $element->setCustomAttributes([
                 'itemsPerPage' => 30,
                 'promoMast'    => 'cat' . $index . '-banner.png',

--- a/tests/FixtureHelper.php
+++ b/tests/FixtureHelper.php
@@ -2,22 +2,21 @@
 namespace DemandwareXml\Test;
 
 use DOMDocument;
-use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTest extends TestCase
+trait FixtureHelper
 {
-    protected function loadFixture($filename)
+    protected function loadFixture(string $filename): DOMDocument
     {
-        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom                     = new DOMDocument('1.0', 'UTF-8');
         $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = false;
+        $dom->formatOutput       = false;
 
         $dom->load(__DIR__ . '/fixtures/' . ltrim($filename, '/'));
 
         return $dom;
     }
 
-    protected function loadJsonFixture($filename)
+    protected function loadJsonFixture(string $filename): array
     {
         return json_decode(file_get_contents(__DIR__ . '/fixtures/' . ltrim($filename, '/')), true);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2,11 +2,14 @@
 namespace DemandwareXml\Test;
 
 use DemandwareXml\Parser;
+use PHPUnit\Framework\TestCase;
 
 // note: don't need to parse variants, so no test for those!
 // rebuild fixtures: file_put_contents(__DIR__ . '/fixtures/categories.json', json_encode($parser->categories(), JSON_PRETTY_PRINT) . PHP_EOL);
-class ParserTest extends AbstractTest
+class ParserTest extends TestCase
 {
+    use FixtureHelper;
+
     public function testMixedParser()
     {
         $parser = $this->getFixtureParser('mixed.xml', true);

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace DemandwareXml\Test;
 
-use DemandwareXml\{Document, Product};
 use DemandwareXml\Test\FixtureHelper;
+use DemandwareXml\{Document, Product};
 use PHPUnit\Framework\TestCase;
 
 class ProductsTest extends TestCase

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -2,9 +2,13 @@
 namespace DemandwareXml\Test;
 
 use DemandwareXml\{Document, Product};
+use DemandwareXml\Test\FixtureHelper;
+use PHPUnit\Framework\TestCase;
 
-class ProductsTest extends AbstractTest
+class ProductsTest extends TestCase
 {
+    use FixtureHelper;
+
     public function testProductsXml()
     {
         $this->assertXmlStringEqualsXmlString(

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -68,7 +68,17 @@ class ProductsTest extends AbstractTest
         $document->save(__DIR__ . '/output/products.xml');
     }
 
-    public function buildDocument(): Document
+    /**
+     * @expectedException       \DemandwareXml\XmlException
+     * @expectedExceptionMessage Sitemap priority must be 1.0 or less
+     */
+    public function testInvalidSitemapPriority()
+    {
+        $element = new Product('PRODUCT123');
+        $element->setSitemap(42.5);
+    }
+
+    protected function buildDocument(): Document
     {
         $document = new Document('TestCatalog');
         $document->addObject($this->buildProductElement());

--- a/tests/VariantsTest.php
+++ b/tests/VariantsTest.php
@@ -1,11 +1,13 @@
 <?php
-namespace FusionsPIM\DemandwareXml\Test;
+namespace DemandwareXml\Test;
 
-use DemandwareXml\Test\AbstractTest;
 use DemandwareXml\{Document, Variant};
+use PHPUnit\Framework\TestCase;
 
-class VariantsTest extends AbstractTest
+class VariantsTest extends TestCase
 {
+    use FixtureHelper;
+
     public function testVariantsXml()
     {
         $document = new Document('TestCatalog');

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -6,6 +6,26 @@ use PHPUnit\Framework\TestCase;
 
 class XmlTest extends TestCase
 {
+    /**
+     * @dataProvider escapeDataProvider
+     */
+    public function testEscape($unescaped, string $escaped)
+    {
+        $this->assertEquals($escaped, Xml::escape($unescaped));
+    }
+
+    public function escapeDataProvider()
+    {
+        return [
+            [true, 'true'],
+            [false, 'false'],
+            [
+                '<el>"Double Quotes" & \'Single Quotes\'</el>',
+                '&lt;el&gt;&quot;Double Quotes&quot; &amp; &apos;Single Quotes&apos;&lt;/el&gt;',
+            ],
+        ];
+    }
+
     public function testSanitise()
     {
         $invalidChar = chr(30); // Record Separator.

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace DemandwareXml\Test;
 
-use DemandwareXml\{Xml, XmlException};
+use DemandwareXml\Xml;
 use PHPUnit\Framework\TestCase;
 
 class XmlTest extends TestCase

--- a/tests/fixtures/categories-simple.json
+++ b/tests/fixtures/categories-simple.json
@@ -5,7 +5,8 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     },
     "CAT1": {
         "name": "Death Stars",
@@ -13,7 +14,8 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     },
     "CAT2": {
         "name": "Donuts",
@@ -21,6 +23,7 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     }
 }

--- a/tests/fixtures/categories.json
+++ b/tests/fixtures/categories.json
@@ -16,7 +16,8 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     },
     "CAT1": {
         "attributes": {
@@ -35,7 +36,8 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     },
     "CAT2": {
         "attributes": {
@@ -54,6 +56,7 @@
         "parent": "CAT0",
         "sitemap-changefrequency": "weekly",
         "sitemap-included-flag": "true",
-        "sitemap-priority": "0.2"
+        "sitemap-priority": "0.2",
+        "start": "2018-01-01T01:01:01"
     }
 }

--- a/tests/fixtures/categories.xml
+++ b/tests/fixtures/categories.xml
@@ -3,6 +3,8 @@
   <category category-id="CAT0">
     <display-name xml:lang="x-default">Socks</display-name>
     <online-flag>true</online-flag>
+    <online-from>2018-01-01T01:01:01</online-from>
+    <online-to>2018-02-02T02:02:02</online-to>
     <parent>CAT0</parent>
     <template>cat-listings.html</template>
     <sitemap-included-flag>true</sitemap-included-flag>
@@ -23,6 +25,8 @@
   <category category-id="CAT1">
     <display-name xml:lang="x-default">Death Stars</display-name>
     <online-flag>true</online-flag>
+    <online-from>2018-01-01T01:01:01</online-from>
+    <online-to>2018-02-02T02:02:02</online-to>
     <parent>CAT0</parent>
     <template>cat-listings.html</template>
     <sitemap-included-flag>true</sitemap-included-flag>
@@ -43,6 +47,8 @@
   <category category-id="CAT2">
     <display-name xml:lang="x-default">Donuts</display-name>
     <online-flag>true</online-flag>
+    <online-from>2018-01-01T01:01:01</online-from>
+    <online-to>2018-02-02T02:02:02</online-to>
     <parent>CAT0</parent>
     <template>cat-listings.html</template>
     <sitemap-included-flag>true</sitemap-included-flag>


### PR DESCRIPTION
- Added online from/to dates to categories test.
- Restructured product test so it’s easier to understand how each element is built and differs.
- Test invalid sitemap priority.
- Add XML escape testing.
- Fix autoloader and namespace issues.
- Convert abstract class to a trait and only use where applicable.