### PR TITLE
Added new low memory parser (v1)

### DIFF
--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -5,19 +5,19 @@ use XMLReader;
 
 class StreamingParser
 {
-    protected $path;
+    protected $file;
 
-    public function __construct(string $path)
+    public function __construct(string $file)
     {
-        $this->path = $path;
+        $this->file = $file;
     }
 
     public function validate(): bool
     {
-        if (! file_exists($this->path)) {
-            throw new XmlException('XML file does not exist: ' . basename($this->path));
-        } elseif (! is_readable($this->path)) {
-            throw new XmlException('XML file is not readable: ' . basename($this->path));
+        if (! file_exists($this->file)) {
+            throw new XmlException('XML file does not exist: ' . basename($this->file));
+        } elseif (! is_readable($this->file)) {
+            throw new XmlException('XML file is not readable: ' . basename($this->file));
         }
 
         $previousErrors = libxml_use_internal_errors(true);
@@ -28,7 +28,7 @@ class StreamingParser
 
         try {
             $reader = new XMLReader;
-            $reader->open($this->path);
+            $reader->open($this->file);
             $reader->setSchema(realpath(__DIR__ . '/../xsd/catalog.xsd'));
 
             while ($reader->read());

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -22,6 +22,7 @@ class StreamingParser
         }
 
         $previousErrors = libxml_use_internal_errors(true);
+        libxml_clear_errors();
 
         set_error_handler(function (int $severity, string $message, string $file, int $line) {
             throw new XmlException($message . ' in ' . basename($file) . ' on line ' . $line, $severity);
@@ -37,13 +38,13 @@ class StreamingParser
             $reader->close();
 
             $errors = libxml_get_errors();
-            libxml_clear_errors();
 
             if (count($errors) > 0) {
                 throw $this->libXmlErrorToException(reset($errors));
             }
         } finally {
             libxml_use_internal_errors($previousErrors);
+            libxml_clear_errors();
             restore_error_handler();
         }
 

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -77,17 +77,10 @@ class StreamingParser
         return new XmlException($level . ': ' . trim($error->message) . ' in ' . basename($error->file) . ' on line ' . $error->line . ' column ' . $error->column, $error->code);
     }
 
-    protected function getXmlReader(): XMLReader
+    protected function parseNodes(string $node): Generator
     {
         $reader = new XMLReader;
         $reader->open($this->file);
-
-        return $reader;
-    }
-
-    protected function parseNodes(string $node): Generator
-    {
-        $reader = $this->getXmlReader();
 
         while ($reader->read()) {
             if ($reader->nodeType !== XMLReader::ELEMENT || $reader->localName !== $node) {

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -176,11 +176,30 @@ class StreamingParser
         return [(string) $element['category-id'] => $this->commonDetails($element)];
     }
 
+    public function getSets(): Generator
+    {
+        foreach ($this->parseNodes(static::ITEM_SET) as $element) {
+            $set = $this->extractSet($element);
+            yield key($set) => reset($set);
+        }
+    }
+
+    protected function extractSet(SimpleXMLElement $element)
+    {
+        $details = $this->commonDetails($element);
+
+        foreach ($element->{'product-set-products'}->{'product-set-product'} as $product) {
+            $details['products'][] = (string) $product['product-id'];
+        }
+
+        return [(string) $element['product-id'] => $details];
+    }
+
     protected function commonDetails(SimpleXMLElement $element): array
     {
-        if ($this->skipAttributes) {
-            $details = [];
-        } else {
+        $details = [];
+
+        if (! $this->skipAttributes) {
             $details = [
                 'attributes' => $this->customAttributes($element),
                 'page'       => $this->pageAttributes($element),

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -1,0 +1,68 @@
+<?php
+namespace DemandwareXml;
+
+use XMLReader;
+
+class StreamingParser
+{
+    protected $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function validate(): bool
+    {
+        if (! file_exists($this->path)) {
+            throw new XmlException('XML file does not exist: ' . basename($this->path));
+        } elseif (! is_readable($this->path)) {
+            throw new XmlException('XML file is not readable: ' . basename($this->path));
+        }
+
+        $previousErrors = libxml_use_internal_errors(true);
+
+        set_error_handler(function (int $severity, string $message, string $file, int $line) {
+            throw new XmlException($message . ' in ' . basename($file) . ' on line ' . $line, $severity);
+        });
+
+        try {
+            $reader = new XMLReader;
+            $reader->open($this->path);
+            $reader->setSchema(realpath(__DIR__ . '/../xsd/catalog.xsd'));
+
+            while ($reader->read());
+
+            $errors = libxml_get_errors();
+            libxml_clear_errors();
+
+            if (count($errors) > 0) {
+                throw $this->libXmlErrorToException(reset($errors));
+            }
+        } finally {
+            libxml_use_internal_errors($previousErrors);
+            restore_error_handler();
+        }
+
+        return true;
+    }
+
+    protected function libXmlErrorToException($error): XMLException
+    {
+        switch ($error->level) {
+            case LIBXML_ERR_WARNING:
+                $level = 'Warning';
+                break;
+
+            case LIBXML_ERR_ERROR:
+                $level = 'Error';
+                break;
+
+            case LIBXML_ERR_FATAL:
+                $level = 'Fatal';
+                break;
+        }
+
+        return new XmlException($level . ': ' . trim($error->message) . ' in ' . basename($error->file) . ' on line ' . $error->line . ' column ' . $error->column, $error->code);
+    }
+}

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -176,6 +176,25 @@ class StreamingParser
         return [(string) $element['category-id'] => $this->commonDetails($element)];
     }
 
+    public function getProducts(): Generator
+    {
+        foreach ($this->parseNodes(static::ITEM_PRODUCT) as $element) {
+            $product = $this->extractProduct($element);
+            yield key($product) => reset($product);
+        }
+    }
+
+    protected function extractProduct(SimpleXMLElement $element): array
+    {
+        $details = $this->commonDetails($element);
+
+        foreach ($element->{'variations'}->{'variants'}->{'variant'} as $variation) {
+            $details['variations'][(string) $variation['product-id']] = isset($variation['default']);
+        }
+
+        return [(string) $element['product-id'] => $details];
+    }
+
     public function getSets(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_SET) as $element) {

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -230,7 +230,7 @@ class StreamingParser
         }
     }
 
-    protected function extractSet(SimpleXMLElement $element)
+    protected function extractSet(SimpleXMLElement $element): array
     {
         $details = $this->commonDetails($element);
 
@@ -253,7 +253,7 @@ class StreamingParser
         }
     }
 
-    protected function extractVariation(SimpleXMLElement $element)
+    protected function extractVariation(SimpleXMLElement $element): array
     {
         return [(string) $element['product-id'] => $this->commonDetails($element)];
     }

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -7,10 +7,12 @@ use XMLReader;
 class StreamingParser
 {
     protected $file;
+    protected $skipAttributes;
 
-    public function __construct(string $file)
+    public function __construct(string $file, bool $skipAttributes = false)
     {
-        $this->file = $file;
+        $this->file           = $file;
+        $this->skipAttributes = $skipAttributes;
     }
 
     public function validate(): bool
@@ -109,6 +111,117 @@ class StreamingParser
         $primary    = (isset($element->{'primary-flag'}) ? ((string) $element->{'primary-flag'}) === 'true': false);
 
         return [$productId => [$categoryId => $primary]];
+    }
+
+    public function getCategories(): iterable
+    {
+        foreach ($this->parseNodes(['category']) as $element) {
+            $category = $this->extractCategory($element);
+            yield key($category) => reset($category);
+        }
+    }
+
+    protected function extractCategory(SimpleXMLElement $element): array
+    {
+        return [(string) $element['category-id'] => $this->commonDetails($element)];
+    }
+
+    protected function commonDetails(SimpleXMLElement $element): array
+    {
+        if ($this->skipAttributes) {
+            $details = [];
+        } else {
+            $details = [
+                'attributes' => $this->customAttributes($element),
+                'page'       => $this->pageAttributes($element),
+            ];
+        }
+
+        $map = [
+            'description'             => 'long-description',
+            'name'                    => 'display-name',
+            'start'                   => 'online-from',
+            'classification'          => 'classification-category',
+            'online'                  => 'online-flag',
+            'searchable'              => 'searchable-flag',
+            'parent'                  => 'parent',
+            'tax'                     => 'tax-class-id',
+            'brand'                   => 'brand',
+            'sitemap-included-flag'   => 'sitemap-included-flag',
+            'sitemap-changefrequency' => 'sitemap-changefrequency',
+            'sitemap-priority'        => 'sitemap-priority',
+        ];
+
+        foreach ($map as $name => $source) {
+            $cleansed = html_entity_decode(trim((string) $element->{$source}));
+
+            if (strlen($cleansed) > 0) {
+                $details[$name] = $cleansed;
+            }
+        }
+
+        // if they exist, online/searchable will always be a true/false string, so cast for ease of use
+        foreach (['online', 'searchable'] as $name) {
+            if (isset($details[$name])) {
+                $details[$name] = filter_var($details[$name], FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        // convert the tax string to a meaningful number
+        if (isset($details['tax'])) {
+            $details['tax'] = (float) str_replace(['TAX_', '_'], ['', '.'], $details['tax']);
+        }
+
+        ksort($details);
+
+        return $details;
+    }
+
+    protected function customAttributes(SimpleXMLElement $element): array
+    {
+        if (! isset($element->{'custom-attributes'}->{'custom-attribute'})) {
+            return [];
+        }
+
+        $attributes = [];
+
+        foreach ($element->{'custom-attributes'}->{'custom-attribute'} as $attribute) {
+            if (isset($attribute->{'value'})) {
+                $value = [];
+
+                foreach ($attribute->{'value'} as $item) {
+                    $value[] = trim((string) $item);
+                }
+            } else {
+                $value = trim((string) $attribute);
+
+                // cast strings to booleans (only needed for single values, as multi-value booleans make no sense)
+                if ('true' === $value || 'false' === $value) {
+                    $value = ('true' === $value);
+                }
+            }
+
+            $attributes[(string) $attribute['attribute-id']] = $value;
+        }
+
+        ksort($attributes);
+
+        return $attributes;
+    }
+
+    protected function pageAttributes(SimpleXMLElement $element): array
+    {
+        $attributes = [];
+
+        foreach (['title', 'description', 'keywords', 'url'] as $part) {
+            $value = html_entity_decode(trim((string) $element->{'page-attributes'}->{'page-' . $part}));
+
+            if (strlen($value) > 0) {
+                $attributes[$part] = $value;
+            }
+        }
+
+        return $attributes;
     }
 
     public static function toArrayGroupedByKey(iterable $items): array

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -128,7 +128,7 @@ class StreamingParser
     public function getAssignments(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_ASSIGNMENT) as $element) {
-            $assignment = $this->extractAssignment($element);
+            $assignment = $this->extractAssignment($element); // @todo: Use array destructuring when on PHP 7.1.
             yield key($assignment) => reset($assignment);
         }
     }
@@ -145,7 +145,7 @@ class StreamingParser
     public function getBundles(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_BUNDLE) as $element) {
-            $bundle = $this->extractBundle($element);
+            $bundle = $this->extractBundle($element); // @todo: Use array destructuring when on PHP 7.1.
             yield key($bundle) => reset($bundle);
         }
     }
@@ -166,7 +166,7 @@ class StreamingParser
     public function getCategories(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_CATEGORY) as $element) {
-            $category = $this->extractCategory($element);
+            $category = $this->extractCategory($element); // @todo: Use array destructuring when on PHP 7.1.
             yield key($category) => reset($category);
         }
     }
@@ -179,7 +179,7 @@ class StreamingParser
     public function getProducts(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_PRODUCT) as $element) {
-            $product = $this->extractProduct($element);
+            $product = $this->extractProduct($element); // @todo: Use array destructuring when on PHP 7.1.
             yield key($product) => reset($product);
         }
     }

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -115,7 +115,7 @@ class StreamingParser
                     ($item === static::ITEM_BUNDLE && isset($element->{'bundled-products'})) ||
                     ($item === static::ITEM_SET && isset($element->{'product-set-products'})) ||
                     ($item === static::ITEM_PRODUCT && isset($element->{'variations'})) ||
-                    ($item === static::ITEM_VARIATION && ! isset($element->{'bundled-products'}, $element->{'product-set-products'}, $element->{'variations'}))
+                    ($item === static::ITEM_VARIATION && ! isset($element->{'bundled-products'}) && ! isset($element->{'product-set-products'}) && ! isset($element->{'variations'}))
                 ) {
                     yield $element;
                 }
@@ -198,7 +198,7 @@ class StreamingParser
     public function getSets(): Generator
     {
         foreach ($this->parseNodes(static::ITEM_SET) as $element) {
-            $set = $this->extractSet($element);
+            $set = $this->extractSet($element); // @todo: Use array destructuring when on PHP 7.1.
             yield key($set) => reset($set);
         }
     }
@@ -212,6 +212,19 @@ class StreamingParser
         }
 
         return [(string) $element['product-id'] => $details];
+    }
+
+    public function getVariations(): Generator
+    {
+        foreach ($this->parseNodes(static::ITEM_VARIATION) as $element) {
+            $variation = $this->extractVariation($element); // @todo: Use array destructuring when on PHP 7.1.
+            yield key($variation) => reset($variation);
+        }
+    }
+
+    protected function extractVariation(SimpleXMLElement $element)
+    {
+        return [(string) $element['product-id'] => $this->commonDetails($element)];
     }
 
     protected function commonDetails(SimpleXMLElement $element): array

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -117,8 +117,7 @@ class StreamingParser
                 $element = new SimpleXMLElement($reader->readOuterXml());
 
                 if (
-                    in_array($item, [static::ITEM_ASSIGNMENT, static::ITEM_CATEGORY]) ||
-                    $item === static::ITEM_PHOTO ||
+                    in_array($item, [static::ITEM_ASSIGNMENT, static::ITEM_CATEGORY, static::ITEM_PHOTO]) ||
                     ($item === static::ITEM_BUNDLE && isset($element->{'bundled-products'})) ||
                     ($item === static::ITEM_SET && isset($element->{'product-set-products'})) ||
                     ($item === static::ITEM_PRODUCT && isset($element->{'variations'})) ||

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -2,7 +2,7 @@
 namespace DemandwareXml;
 
 use Generator;
-use SimpleXMLElement;;
+use SimpleXMLElement;
 use XMLReader;
 
 class StreamingParser

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -35,14 +35,13 @@ class StreamingParser
 
             while ($reader->read());
 
-            $reader->close();
-
             $errors = libxml_get_errors();
 
             if (count($errors) > 0) {
                 throw $this->libXmlErrorToException(reset($errors));
             }
         } finally {
+            $reader->close();
             libxml_use_internal_errors($previousErrors);
             libxml_clear_errors();
             restore_error_handler();

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -26,11 +26,15 @@ class StreamingParser
     ];
 
     protected $file;
-    protected $skipAttributes;
+    protected $skipAttributes = false;
 
-    public function __construct(string $file, bool $skipAttributes = false)
+    public function __construct(string $file)
     {
-        $this->file           = $file;
+        $this->file = $file;
+    }
+
+    public function skipAttributes(bool $skipAttributes)
+    {
         $this->skipAttributes = $skipAttributes;
     }
 

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -20,7 +20,8 @@ class StreamingParser
         $this->skipAttributes = $skipAttributes;
     }
 
-    public function validate(): bool
+    // Validation without a schema is allowed for photos as they don't have one.
+    public function validate($useSchema = true): bool
     {
         if (! file_exists($this->file)) {
             throw new XmlException('XML file does not exist: ' . basename($this->file));
@@ -38,7 +39,10 @@ class StreamingParser
         try {
             $reader = new XMLReader;
             $reader->open($this->file);
-            $reader->setSchema(realpath(__DIR__ . '/../xsd/catalog.xsd'));
+
+            if ($useSchema) {
+                $reader->setSchema(realpath(__DIR__ . '/../xsd/catalog.xsd'));
+            }
 
             while ($reader->read());
 

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -1,7 +1,8 @@
 <?php
 namespace DemandwareXml;
 
-use SimpleXMLElement;
+use Generator;
+use SimpleXMLElement;;
 use XMLReader;
 
 class StreamingParser
@@ -79,7 +80,7 @@ class StreamingParser
         return $reader;
     }
 
-    protected function parseNodes(array $nodes): iterable
+    protected function parseNodes(array $nodes): Generator
     {
         try {
             $reader = $this->getXmlReader();
@@ -96,7 +97,7 @@ class StreamingParser
         }
     }
 
-    public function getAssignments(): iterable
+    public function getAssignments(): Generator
     {
         foreach ($this->parseNodes(['category-assignment']) as $element) {
             $assignment = $this->extractAssignment($element);
@@ -113,7 +114,7 @@ class StreamingParser
         return [$productId => [$categoryId => $primary]];
     }
 
-    public function getCategories(): iterable
+    public function getCategories(): Generator
     {
         foreach ($this->parseNodes(['category']) as $element) {
             $category = $this->extractCategory($element);

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -311,14 +311,14 @@ class StreamingParser
             }
         }
 
-        // if they exist, online/searchable will always be a true/false string, so cast for ease of use
+        // If they exist, online/searchable will always be a true/false string, so cast for ease of use.
         foreach (['online', 'searchable'] as $name) {
             if (isset($details[$name])) {
                 $details[$name] = filter_var($details[$name], FILTER_VALIDATE_BOOLEAN);
             }
         }
 
-        // convert the tax string to a meaningful number
+        // Convert the tax string to a meaningful number.
         if (isset($details['tax'])) {
             $details['tax'] = (float) str_replace(['TAX_', '_'], ['', '.'], $details['tax']);
         }
@@ -346,7 +346,7 @@ class StreamingParser
             } else {
                 $value = trim((string) $attribute);
 
-                // cast strings to booleans (only needed for single values, as multi-value booleans make no sense)
+                // Cast strings to booleans (only needed for single values, as multi-value booleans make no sense).
                 if ('true' === $value || 'false' === $value) {
                     $value = ('true' === $value);
                 }

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -223,15 +223,4 @@ class StreamingParser
 
         return $attributes;
     }
-
-    public static function toArrayGroupedByKey(iterable $items): array
-    {
-        $results = [];
-
-        foreach ($items as $key => $item) {
-            $results[$key][] = $item;
-        }
-
-        return $results;
-    }
 }

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -42,4 +42,24 @@ class StreamingParserTest extends TestCase
             StreamingParser::toArrayGroupedByKey($parser->getAssignments())
         );
     }
+
+    public function testCategoriesParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/categories.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('categories.json'),
+            iterator_to_array($parser->getCategories())
+        );
+    }
+
+    public function testSimpleCategoriesParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/categories.xml', $skipAttributes = true);
+
+        $this->assertEquals(
+            $this->loadJsonFixture('categories-simple.json'),
+            iterator_to_array($parser->getCategories())
+        );
+    }
 }

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -21,6 +21,15 @@ class StreamingParserTest extends TestCase
     }
 
     /**
+     * @expectedException              \DemandwareXml\XmlException
+     * @expectedExceptionMessageRegExp /Error: Element '{.*}upc': This element is not expected. Expected is one of \( {.*}step-quantity, {.*}display-name, {.*}short-description, {.*}long-description, {.*}store-receipt-name, {.*}store-tax-class, {.*}store-force-price-flag, {.*}store-non-inventory-flag, {.*}store-non-revenue-flag, {.*}store-non-discountable-flag \). in invalid-schema-products.xml/
+     */
+    public function testParserValidateInvalidSchemaXml()
+    {
+        (new StreamingParser(__DIR__ . '/fixtures/invalid-schema-products.xml'))->validate();
+    }
+
+    /**
      * @expectedException        \DemandwareXml\XMLException
      * @expectedExceptionMessage XML file does not exist: fake-products.xml
      */

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -89,6 +89,26 @@ class StreamingParserTest extends TestCase
         );
     }
 
+    public function testProductsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('products.json'),
+            iterator_to_array($parser->getProducts())
+        );
+    }
+
+    public function testSimpleProductsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+
+        $this->assertEquals(
+            $this->loadJsonFixture('products-simple.json'),
+            iterator_to_array($parser->getProducts())
+        );
+    }
+
     public function testSetsParser()
     {
         $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -11,8 +11,8 @@ class StreamingParserTest extends TestCase
     use FixtureHelper;
 
     /**
-     * @expectedException        \DemandwareXml\XmlException
-     * @expectedExceptionMessage Fatal: xmlParseEntityRef: no name in invalid-products.xml on line 8 column 113
+     * @expectedException              \DemandwareXml\XmlException
+     * @expectedExceptionMessageRegExp /Fatal: xmlParseEntityRef: no name in invalid-products.xml/
      */
     public function testParserValidateInvalidXml()
     {

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -61,7 +61,8 @@ class StreamingParserTest extends TestCase
 
     public function testSimpleBundlesParser()
     {
-        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+        $parser->skipAttributes(true);
 
         $this->assertEquals(
             $this->loadJsonFixture('bundles-simple.json'),
@@ -81,7 +82,8 @@ class StreamingParserTest extends TestCase
 
     public function testSimpleCategoriesParser()
     {
-        $parser = new StreamingParser(__DIR__ . '/fixtures/categories.xml', $skipAttributes = true);
+        $parser = new StreamingParser(__DIR__ . '/fixtures/categories.xml');
+        $parser->skipAttributes(true);
 
         $this->assertEquals(
             $this->loadJsonFixture('categories-simple.json'),
@@ -111,7 +113,8 @@ class StreamingParserTest extends TestCase
 
     public function testSimpleProductsParser()
     {
-        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+        $parser->skipAttributes(true);
 
         $this->assertEquals(
             $this->loadJsonFixture('products-simple.json'),
@@ -131,7 +134,8 @@ class StreamingParserTest extends TestCase
 
     public function testSimpleSetsParser()
     {
-        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+        $parser->skipAttributes(true);
 
         $this->assertEquals(
             $this->loadJsonFixture('sets-simple.json'),
@@ -151,7 +155,8 @@ class StreamingParserTest extends TestCase
 
     public function testSimpleVariationsParser()
     {
-        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+        $parser->skipAttributes(true);
 
         $this->assertEquals(
             $this->loadJsonFixture('variations-simple.json'),

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -128,4 +128,24 @@ class StreamingParserTest extends TestCase
             iterator_to_array($parser->getSets())
         );
     }
+
+    public function testVariationsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('variations.json'),
+            iterator_to_array($parser->getVariations())
+        );
+    }
+
+    public function testSimpleVariationsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+
+        $this->assertEquals(
+            $this->loadJsonFixture('variations-simple.json'),
+            iterator_to_array($parser->getVariations())
+        );
+    }
 }

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -32,4 +32,14 @@ class StreamingParserTest extends TestCase
     {
         $this->assertTrue((new StreamingParser(__DIR__ . '/fixtures/products.xml'))->validate());
     }
+
+    public function testAssignmentsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/assignments.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('assignments.json'),
+            StreamingParser::toArrayGroupedByKey($parser->getAssignments())
+        );
+    }
 }

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -49,6 +49,26 @@ class StreamingParserTest extends TestCase
         );
     }
 
+    public function testBundlesParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('bundles.json'),
+            iterator_to_array($parser->getBundles())
+        );
+    }
+
+    public function testSimpleBundlesParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+
+        $this->assertEquals(
+            $this->loadJsonFixture('bundles-simple.json'),
+            iterator_to_array($parser->getBundles())
+        );
+    }
+
     public function testCategoriesParser()
     {
         $parser = new StreamingParser(__DIR__ . '/fixtures/categories.xml');

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -89,6 +89,16 @@ class StreamingParserTest extends TestCase
         );
     }
 
+    public function testPhotosParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/photos.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('photos.json'),
+            iterator_to_array($parser->getPhotos())
+        );
+    }
+
     public function testProductsParser()
     {
         $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -88,4 +88,24 @@ class StreamingParserTest extends TestCase
             iterator_to_array($parser->getCategories())
         );
     }
+
+    public function testSetsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml');
+
+        $this->assertEquals(
+            $this->loadJsonFixture('sets.json'),
+            iterator_to_array($parser->getSets())
+        );
+    }
+
+    public function testSimpleSetsParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/products.xml', $skipAttributes = true);
+
+        $this->assertEquals(
+            $this->loadJsonFixture('sets-simple.json'),
+            iterator_to_array($parser->getSets())
+        );
+    }
 }

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace DemandwareXml\Test;
 
-use Generator;
 use DemandwareXml\StreamingParser;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 // note: don't need to parse variants, so no test for those!

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -37,9 +37,15 @@ class StreamingParserTest extends TestCase
     {
         $parser = new StreamingParser(__DIR__ . '/fixtures/assignments.xml');
 
+        $assignments = [];
+
+        foreach ($parser->getAssignments() as $productId => $assignment) {
+            $assignments[$productId][] = $assignment;
+        }
+
         $this->assertEquals(
             $this->loadJsonFixture('assignments.json'),
-            StreamingParser::toArrayGroupedByKey($parser->getAssignments())
+            $assignments
         );
     }
 

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace DemandwareXml\Test;
+
+use DemandwareXml\StreamingParser;
+use PHPUnit\Framework\TestCase;
+
+// note: don't need to parse variants, so no test for those!
+// rebuild fixtures: file_put_contents(__DIR__ . '/fixtures/categories.json', json_encode($parser->categories(), JSON_PRETTY_PRINT) . PHP_EOL);
+class StreamingParserTest extends TestCase
+{
+    use FixtureHelper;
+
+    /**
+     * @expectedException        \DemandwareXml\XmlException
+     * @expectedExceptionMessage Fatal: xmlParseEntityRef: no name in invalid-products.xml on line 8 column 113
+     */
+    public function testParserValidateInvalidXml()
+    {
+        (new StreamingParser(__DIR__ . '/fixtures/invalid-products.xml'))->validate();
+    }
+
+    /**
+     * @expectedException        \DemandwareXml\XMLException
+     * @expectedExceptionMessage XML file does not exist: fake-products.xml
+     */
+    public function testParserValidateFileDoesNotExist()
+    {
+        (new StreamingParser(__DIR__ . '/fixtures/fake-products.xml'))->validate();
+    }
+
+    public function testParserValidate()
+    {
+        $this->assertTrue((new StreamingParser(__DIR__ . '/fixtures/products.xml'))->validate());
+    }
+}

--- a/tests/StreamingParserTest.php
+++ b/tests/StreamingParserTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace DemandwareXml\Test;
 
+use Generator;
 use DemandwareXml\StreamingParser;
 use PHPUnit\Framework\TestCase;
 
@@ -31,6 +32,19 @@ class StreamingParserTest extends TestCase
     public function testParserValidate()
     {
         $this->assertTrue((new StreamingParser(__DIR__ . '/fixtures/products.xml'))->validate());
+    }
+
+    public function testEmptyParser()
+    {
+        $parser = new StreamingParser(__DIR__ . '/fixtures/empty.xml');
+
+        $this->assertEmpty(iterator_to_array($parser->getAssignments()));
+        $this->assertEmpty(iterator_to_array($parser->getBundles()));
+        $this->assertEmpty(iterator_to_array($parser->getCategories()));
+        $this->assertEmpty(iterator_to_array($parser->getPhotos()));
+        $this->assertEmpty(iterator_to_array($parser->getProducts()));
+        $this->assertEmpty(iterator_to_array($parser->getSets()));
+        $this->assertEmpty(iterator_to_array($parser->getVariations()));
     }
 
     public function testAssignmentsParser()

--- a/tests/fixtures/empty.xml
+++ b/tests/fixtures/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="TestCatalog">
+</catalog>

--- a/tests/fixtures/invalid-schema-products.xml
+++ b/tests/fixtures/invalid-schema-products.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="TestCatalog">
+    <product product-id="PRODUCT123">
+        <min-order-quantity>1</min-order-quantity> <!-- This line should be below UPC in order to match the schema. -->
+        <upc>500000000000</upc>
+        <step-quantity>1</step-quantity>
+        <display-name xml:lang="x-default">Product number 123</display-name>
+        <long-description xml:lang="x-default">The description for an example product! &amp;bull; Bullet Point &amp; this is broken</long-description>
+        <online-flag>true</online-flag>
+        <online-from>2015-01-23T01:23:45</online-from>
+        <online-to>2025-01-23T01:23:45</online-to>
+        <searchable-flag>false</searchable-flag>
+        <brand>SampleBrand™</brand>
+        <search-rank>1</search-rank>
+        <sitemap-included-flag>true</sitemap-included-flag>
+        <sitemap-changefrequency>weekly</sitemap-changefrequency>
+        <sitemap-priority>0.5</sitemap-priority>
+        <page-attributes>
+            <page-title xml:lang="x-default">Amazing Product</page-title>
+            <page-description xml:lang="x-default">Buy our Product today!</page-description>
+            <page-keywords xml:lang="x-default">Product, test, example</page-keywords>
+            <page-url xml:lang="x-default">http://example.com/product/123</page-url>
+        </page-attributes>
+        <custom-attributes>
+            <custom-attribute attribute-id="boolFalse">false</custom-attribute>
+            <custom-attribute attribute-id="boolTrue">true</custom-attribute>
+            <custom-attribute attribute-id="multiWow">
+                <value>so</value>
+                <value>such</value>
+                <value>many</value>
+                <value>much</value>
+                <value>very</value>
+            </custom-attribute>
+            <custom-attribute attribute-id="primaryImage">product-123.png</custom-attribute>
+            <custom-attribute attribute-id="type">Examples</custom-attribute>
+            <custom-attribute attribute-id="zzz">Should be exported last within custom-attributes</custom-attribute>
+        </custom-attributes>
+        <variations>
+            <attributes>
+                <shared-variation-attribute variation-attribute-id="AT001" attribute-id="AT001"/>
+                <shared-variation-attribute variation-attribute-id="AT002" attribute-id="AT002"/>
+            </attributes>
+            <variants>
+                <variant product-id="SKU0000001"/>
+                <variant product-id="SKU0000002"/>
+                <variant product-id="SKU0000003" default="true"/>
+            </variants>
+        </variations>
+        <classification-category catalog-id="TestCatalog">CAT123</classification-category>
+    </product>
+</catalog>

--- a/tests/fixtures/photos.json
+++ b/tests/fixtures/photos.json
@@ -1,0 +1,18 @@
+{
+  "PROD1": {
+    "enriched": true,
+    "images": {
+      "main": "FOOBAR",
+      "swatch": "FOOBAR_swatch"
+    }
+  },
+  "PROD2": {
+    "enriched": true,
+    "images": {
+      "main": "FOOBAR",
+      "image1": "FOOBAR_B",
+      "image2": "FOOBAR_C",
+      "image3": "FOOBAR_D"
+    }
+  }
+}

--- a/tests/fixtures/photos.xml
+++ b/tests/fixtures/photos.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<products>
+    <product product-id="PROD1">
+        <custom-attribute attribute-id="primaryImage">FOOBAR</custom-attribute>
+        <custom-attribute attribute-id="productEnriched">true</custom-attribute>
+        <custom-attribute attribute-id="imageSwatch">FOOBAR_swatch</custom-attribute>
+    </product>
+
+    <product product-id="PROD2">
+        <custom-attribute attribute-id="primaryImage">FOOBAR</custom-attribute>
+        <custom-attribute attribute-id="productEnriched">true</custom-attribute>
+        <custom-attribute attribute-id="secondaryImage1">FOOBAR_B</custom-attribute>
+        <custom-attribute attribute-id="secondaryImage2">FOOBAR_C</custom-attribute>
+        <custom-attribute attribute-id="secondaryImage3">FOOBAR_D</custom-attribute>
+    </product>
+</products>


### PR DESCRIPTION
I've added a new low memory parser:

- Uses `yield` to return each element, which results in reduced memory usage.
- Validates XML using `XMLReader` so document does not have to be loaded into memory.
- Supports parsing legacy photo XML.
- Validation is done directly via a method, rather than in the constructor like `Parser`, for flexibility.
