### PR TITLE
Allow categories to be deleted

### DIFF
--- a/src/Category.php
+++ b/src/Category.php
@@ -20,4 +20,12 @@ class Category extends Base
     {
         $this->elements['parent'] = $value;
     }
+
+    /**
+     * Sets the `mode` attribute to "delete"
+     */
+    public function setDeleted()
+    {
+        $this->attributes['mode'] = 'delete';
+    }
 }

--- a/tests/CategoriesTest.php
+++ b/tests/CategoriesTest.php
@@ -66,4 +66,22 @@ class CategoriesTest extends TestCase
 
         $this->assertEqualXMLStructure($sampleXml->firstChild, $outputXml->firstChild);
     }
+
+    public function testCategoriesDeletedXml()
+    {
+        $document = new Document('TestCatalog');
+
+        $element = new Category('CAT123');
+        $element->setDeleted();
+        $document->addObject($element);
+
+        $element = new Category('CAT456');
+        $element->setDeleted();
+        $document->addObject($element);
+
+        $sampleXml = $this->loadFixture('category-deleted.xml');
+        $outputXml = $document->getDomDocument()->saveXML();
+
+        $this->assertXmlStringEqualsXmlString($sampleXml, $outputXml);
+    }
 }

--- a/tests/fixtures/category-deleted.xml
+++ b/tests/fixtures/category-deleted.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="TestCatalog">
+  <category category-id="CAT123" mode="delete"/>
+  <category category-id="CAT456" mode="delete"/>
+</catalog>


### PR DESCRIPTION
This allows us to set the mode for a category to `delete`, in the same way we can for products.