### PR TITLE
Call libxml_clear_errors() before we start capturing further errors

### DIFF
--- a/src/Xml.php
+++ b/src/Xml.php
@@ -54,6 +54,7 @@ class Xml
             return false;
         }
 
+        libxml_clear_errors();
         libxml_use_internal_errors(true);
 
         set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext): void {


### PR DESCRIPTION
Currently unit tests in an application that uses this library are failing when the tests are run in a certain order. This seems to be because `libxml_clear_errors()` is not being called frequently enough.

For instance, a unit test which attempts to catch xml validation issues and expects the following
```
Entity 'bull' not defined\n\tLines: 4\n\nThe document has no document element.\n\tLines: -1
```
will receive
```
Entity 'bull' not defined\n\tLines: 6, 2, 9, 4, 4\n\nchunk is not well balanced\n\tLines: 10, 5, 21, 19\n\nThe document has no document element.\n\tLines: -1
```
if errors have occurred in other tests