### PR TITLE
Fix setSitemap Typehints

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -61,7 +61,7 @@ abstract class Base
      *
      * @throws XmlException
      */
-    public function setSitemap(float $priority = null, bool $included = true, string $frequency = 'weekly'): void
+    public function setSitemap(?float $priority = null, ?bool $included = true, ?string $frequency = 'weekly'): void
     {
         if ($priority > 1) {
             throw new XmlException('Sitemap priority must be 1.0 or less');

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -71,6 +71,30 @@ class ProductsTest extends TestCase
         $document->save(__DIR__ . '/output/products.xml');
     }
 
+    public function testSetSitemap(): void
+    {
+        $element = new Product('PRODUCT123');
+        $element->setSitemap(0.5);
+        $this->assertEquals([
+            'sitemap-priority'        => '0.5',
+            'sitemap-included-flag'   => true,
+            'sitemap-changefrequency' => 'weekly',
+        ], $element->getElements());
+
+        $element = new Product('PRODUCT123');
+        $element->setSitemap(1, null, null);
+        $this->assertEquals([
+            'sitemap-priority' => '1.0'
+        ], $element->getElements());
+
+        $element = new Product('PRODUCT123');
+        $element->setSitemap(null, true, 'daily');
+        $this->assertEquals([
+            'sitemap-included-flag'   => true,
+            'sitemap-changefrequency' => 'daily',
+        ], $element->getElements());
+    }
+
     /**
      * @expectedException       \DemandwareXml\XmlException
      * @expectedExceptionMessage Sitemap priority must be 1.0 or less

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -71,28 +71,41 @@ class ProductsTest extends TestCase
         $document->save(__DIR__ . '/output/products.xml');
     }
 
-    public function testSetSitemap(): void
+    /**
+     * @dataProvider setSitemapDataProvider
+     */
+    public function testSetSitemap(array $params, array $expectedElements): void
     {
         $element = new Product('PRODUCT123');
-        $element->setSitemap(0.5);
-        $this->assertEquals([
-            'sitemap-priority'        => '0.5',
-            'sitemap-included-flag'   => true,
-            'sitemap-changefrequency' => 'weekly',
-        ], $element->getElements());
+        $element->setSitemap(...$params);
+        $this->assertEquals($expectedElements, $element->getElements());
+    }
 
-        $element = new Product('PRODUCT123');
-        $element->setSitemap(1, null, null);
-        $this->assertEquals([
-            'sitemap-priority' => '1.0',
-        ], $element->getElements());
-
-        $element = new Product('PRODUCT123');
-        $element->setSitemap(null, true, 'daily');
-        $this->assertEquals([
-            'sitemap-included-flag'   => true,
-            'sitemap-changefrequency' => 'daily',
-        ], $element->getElements());
+    public function setSitemapDataProvider(): array
+    {
+        return [
+            [
+                ['0.5'],
+                [
+                    'sitemap-priority'        => '0.5',
+                    'sitemap-included-flag'   => true,
+                    'sitemap-changefrequency' => 'weekly',
+                ],
+            ],
+            [
+                [1, null, null],
+                [
+                    'sitemap-priority' => '1.0',
+                ],
+            ],
+            [
+                [null, true, 'daily'],
+                [
+                    'sitemap-included-flag'   => true,
+                    'sitemap-changefrequency' => 'daily',
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -84,7 +84,7 @@ class ProductsTest extends TestCase
         $element = new Product('PRODUCT123');
         $element->setSitemap(1, null, null);
         $this->assertEquals([
-            'sitemap-priority' => '1.0'
+            'sitemap-priority' => '1.0',
         ], $element->getElements());
 
         $element = new Product('PRODUCT123');


### PR DESCRIPTION
To simplify https://github.com/fusionspim/fusions/pull/8172

The `is_null` checks within this method suggest that it was designed with the possibility of parameters being null. 