### PR TITLE
Output Empty Tags for Online From / To

### DIFF
--- a/src/Writer/EntityWriter/ProductXmlWriter.php
+++ b/src/Writer/EntityWriter/ProductXmlWriter.php
@@ -25,8 +25,8 @@ class ProductXmlWriter
         $this->writer->ifNotEmpty()->writeElementWithAttributes('display-name', $this->product->displayName, ['xml:lang' => 'x-default']);
         $this->writer->ifNotEmpty()->writeElementWithAttributes('long-description', XmlFormatter::sanitise($this->product->longDescription), ['xml:lang' => 'x-default']);
         $this->writer->ifNotEmpty()->writeElement('online-flag', XmlFormatter::fromBoolean($this->product->onlineFlag));
-        $this->writer->ifNotEmpty()->writeElement('online-from', XmlFormatter::fromDateTime($this->product->onlineFrom));
-        $this->writer->ifNotEmpty()->writeElement('online-to', XmlFormatter::fromDateTime($this->product->onlineTo));
+        $this->writer->writeElement('online-from', XmlFormatter::fromDateTime($this->product->onlineFrom));
+        $this->writer->writeElement('online-to', XmlFormatter::fromDateTime($this->product->onlineTo));
         $this->writer->ifNotEmpty()->writeElement('available-flag', XmlFormatter::fromBoolean($this->product->availableFlag));
         $this->writer->ifNotEmpty()->writeElement('searchable-flag', XmlFormatter::fromBoolean($this->product->searchableFlag));
         $this->writer->ifNotEmpty()->writeElement('searchable-if-unavailable-flag', XmlFormatter::fromBoolean($this->product->searchableIfUnavailableFlag));

--- a/tests/Writer/ProductsTest.php
+++ b/tests/Writer/ProductsTest.php
@@ -132,7 +132,7 @@ class ProductsTest extends TestCase
 
     protected function buildMinimalProductElement(): Product
     {
-        $element = new Product( 'PRD12340000');
+        $element = new Product('PRD12340000');
         $element->setDisplayName('Minimal Product');
         $element->setLongDescription('This minimal product tests how empty fields are output');
 

--- a/tests/Writer/ProductsTest.php
+++ b/tests/Writer/ProductsTest.php
@@ -76,6 +76,7 @@ class ProductsTest extends TestCase
         $xml->startDocument();
         $xml->startCatalog('TestCatalog');
         $xml->writeEntity($this->buildProductElement());
+        $xml->writeEntity($this->buildMinimalProductElement());
         $xml->writeEntity($this->buildSetElement());
         $xml->writeEntity($this->buildBundleElement());
         $xml->writeEntity($this->buildVariationElement());
@@ -125,6 +126,15 @@ class ProductsTest extends TestCase
         }
 
         $element->setImages([mb_strtolower($type) . '-123.png']);
+
+        return $element;
+    }
+
+    protected function buildMinimalProductElement(): Product
+    {
+        $element = new Product( 'PRD12340000');
+        $element->setDisplayName('Minimal Product');
+        $element->setLongDescription('This minimal product tests how empty fields are output');
 
         return $element;
     }

--- a/tests/fixtures/products.xml
+++ b/tests/fixtures/products.xml
@@ -53,6 +53,12 @@
     </variations>
     <classification-category catalog-id="TestCatalog">CAT123</classification-category>
   </product>
+  <product product-id="PRD12340000">
+    <display-name xml:lang="x-default">Minimal Product</display-name>
+    <long-description xml:lang="x-default">This minimal product tests how empty fields are output</long-description>
+    <online-from></online-from>
+    <online-to></online-to>
+  </product>
   <product product-id="SET123">
     <upc>500000000001</upc>
     <min-order-quantity>1</min-order-quantity>


### PR DESCRIPTION
When dates are cleared they need to be sent out as empty tags, otherwise they are left in Demand-ware.