### PR TITLE
Remove new lines between commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
   },
   "scripts": {
     "fix": [
-      "php-cs-fixer fix --config=.php_cs.dist; echo",
-      "composer normalize; echo"
+      "php-cs-fixer fix --config=.php_cs.dist",
+      "composer normalize"
     ],
     "test": [
-      "phpunit --stop-on-failure --stop-on-error; echo"
+      "phpunit --stop-on-failure --stop-on-error"
     ]
   }
 }


### PR DESCRIPTION
As turned out to be confusing rather than useful.