### PR TITLE
Amend unit tests ready for PHPUnit10

### DIFF
--- a/tests/FixtureHelper.php
+++ b/tests/FixtureHelper.php
@@ -5,7 +5,7 @@ use DOMDocument;
 
 trait FixtureHelper
 {
-    protected function loadFixture(string $filename): DOMDocument
+    protected function loadFixture(string $filename): string
     {
         $dom                     = new DOMDocument('1.0', 'UTF-8');
         $dom->preserveWhiteSpace = false;
@@ -13,7 +13,7 @@ trait FixtureHelper
 
         $dom->load(TEST_FIXTURE_DIR . '/' . ltrim($filename, '/'));
 
-        return $dom;
+        return $dom->saveXML();
     }
 
     protected function loadJsonFixture(string $filename): array


### PR DESCRIPTION
`phpunit` is showing warnings here

```
PHPUnit 9.5.1 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

WWWWWW.W.........................................                 49 / 49 (100%)

Time: 00:00.037, Memory: 6.00 MB

There were 7 warnings:

1) DemandwareXml\Test\Writer\CategoriesTest::test_categories_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

2) DemandwareXml\Test\Writer\CategoriesTest::test_assignments_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

3) DemandwareXml\Test\Writer\CategoriesTest::test_categories_deleted_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

4) DemandwareXml\Test\Writer\ProductsTest::test_products_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

5) DemandwareXml\Test\Writer\ProductsTest::test_products_deleted_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

6) DemandwareXml\Test\Writer\ProductsTest::test_xml_escaping
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.

7) DemandwareXml\Test\Writer\VariantsTest::test_variants_xml
Passing an argument of type DOMDocument for the $expectedXml parameter is deprecated. Support for this will be removed in PHPUnit 10.
```
Returning the output as a string instead of DOMDocument fixes the issue