### PR TITLE
Update action versions and GHCR username

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
 version: 2
 
 # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 updates:
   - package-ecosystem: "composer"
     open-pull-requests-limit: 1
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "Dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly" # Enough for awareness, but assume we'd notice bugs (and aren't in a great rush for new features)
     labels:
       - "Dependencies"

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -17,10 +17,10 @@ jobs:
         image: [php-cli]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set Up Docker BuildX
         id: buildx
@@ -29,14 +29,14 @@ jobs:
           install: true
 
       - name: Log In to Github Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: fusionsbot
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./docker/${{ matrix.image }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
           - '8.2'
           - '8.3'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -28,7 +28,7 @@ jobs:
 
       - name: Restore Composer dependencies
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
- Use [documented username](https://github.com/docker/login-action?tab=readme-ov-file#github-container-registry) for logging into GHCR
- Update actions to more recent versions (but let Dependabot do that in the future)