### PR TITLE
Update phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="./tests/bootstrap.php"
-         cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    executionOrder="defects"
+    colors="true"
+    bootstrap="./tests/bootstrap.php"
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
 >
-  <coverage/>
   <testsuites>
-    <testsuite name="Fusions Test Suite">
+    <testsuite name="Unit">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
   <source>
     <include>
-      <directory>./src</directory>
+      <directory suffix=".php">./src</directory>
     </include>
   </source>
 </phpunit>


### PR DESCRIPTION
See : https://github.com/sebastianbergmann/phpunit/releases

> The XML configuration file generator now references vendor/phpunit/phpunit/phpunit.xsd (instead of https://schema.phpunit.de/X.Y/phpunit.xsd) when PHPUnit was installed using Composer and phpunit --generate-configuration was invoked in the directory where vendor is located

Also aligned other config options with our main repo.