### PR TITLE
Reorders set page attributes

### DIFF
--- a/src/Writer/Entity/Category.php
+++ b/src/Writer/Entity/Category.php
@@ -70,7 +70,7 @@ class Category implements WriteableEntityInterface
         $this->sitemapChangeFrequency = $sitemapChangeFrequency;
     }
 
-    public function setPageAttributes(?string $pageTitle = null, ?string $pageDescription = null, ?string $pageKeywords = null, ?string $pageUrl = null): void
+    public function setPageAttributes(?string $pageTitle = null, ?string $pageDescription = null, ?string $pageUrl = null, ?string $pageKeywords = null): void
     {
         $this->pageAttributes = [
             'page-title'       => $pageTitle,

--- a/src/Writer/Entity/Product.php
+++ b/src/Writer/Entity/Product.php
@@ -146,7 +146,7 @@ class Product implements WriteableEntityInterface
         $this->sitemapChangeFrequency = $sitemapChangeFrequency;
     }
 
-    public function setPageAttributes(?string $pageTitle, ?string $pageDescription, ?string $pageKeywords, ?string $pageUrl): void
+    public function setPageAttributes(?string $pageTitle, ?string $pageDescription, ?string $pageUrl, ?string $pageKeywords): void
     {
         $this->pageAttributes = [
             'page-title'       => $pageTitle,

--- a/src/Writer/Entity/Product.php
+++ b/src/Writer/Entity/Product.php
@@ -146,7 +146,7 @@ class Product implements WriteableEntityInterface
         $this->sitemapChangeFrequency = $sitemapChangeFrequency;
     }
 
-    public function setPageAttributes(?string $pageTitle, ?string $pageDescription, ?string $pageUrl, ?string $pageKeywords = null): void
+    public function setPageAttributes(?string $pageTitle = null, ?string $pageDescription = null, ?string $pageUrl = null, ?string $pageKeywords = null): void
     {
         $this->pageAttributes = [
             'page-title'       => $pageTitle,

--- a/src/Writer/Entity/Product.php
+++ b/src/Writer/Entity/Product.php
@@ -146,7 +146,7 @@ class Product implements WriteableEntityInterface
         $this->sitemapChangeFrequency = $sitemapChangeFrequency;
     }
 
-    public function setPageAttributes(?string $pageTitle, ?string $pageDescription, ?string $pageUrl, ?string $pageKeywords): void
+    public function setPageAttributes(?string $pageTitle, ?string $pageDescription, ?string $pageUrl, ?string $pageKeywords = null): void
     {
         $this->pageAttributes = [
             'page-title'       => $pageTitle,

--- a/tests/Writer/CategoriesTest.php
+++ b/tests/Writer/CategoriesTest.php
@@ -54,7 +54,7 @@ class CategoriesTest extends TestCase
             $element->setTemplate('cat-listings.html');
             $element->setOnlineFlag(true);
             $element->setSitemap(0.2);
-            $element->setPageAttributes($title, 'Buy ' . $title, mb_strtolower($title), '/' . $title);
+            $element->setPageAttributes($title, 'Buy ' . $title, '/' . $title,mb_strtolower($title));
             $element->setOnlineFromTo(
                 $data['dates']['from'],
                 $data['dates']['to']

--- a/tests/Writer/CategoriesTest.php
+++ b/tests/Writer/CategoriesTest.php
@@ -54,7 +54,7 @@ class CategoriesTest extends TestCase
             $element->setTemplate('cat-listings.html');
             $element->setOnlineFlag(true);
             $element->setSitemap(0.2);
-            $element->setPageAttributes($title, 'Buy ' . $title, '/' . $title,mb_strtolower($title));
+            $element->setPageAttributes($title, 'Buy ' . $title, '/' . $title, mb_strtolower($title));
             $element->setOnlineFromTo(
                 $data['dates']['from'],
                 $data['dates']['to']

--- a/tests/Writer/ProductsTest.php
+++ b/tests/Writer/ProductsTest.php
@@ -135,8 +135,8 @@ class ProductsTest extends TestCase
         $element->setPageAttributes(
             'Amazing ' . $type,
             'Buy our ' . $type . ' today!',
+            'http://example.com/' . mb_strtolower($type) . '/123',
             $type . ', test, example',
-            'http://example.com/' . mb_strtolower($type) . '/123'
         );
 
         $element->addCustomAttributes([


### PR DESCRIPTION
Re orders the `setPageAttribute` param, adjusts tests to match.

Also adds a default of null to the keywords param of the Product class.  

Could probably null the other params  as per the Category class?

