### PR TITLE
Add assignees to Dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,13 @@ updates:
       interval: "daily"
     labels:
       - "Dependencies"
+    assignees:
+      - "MizouziE"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly" # Enough for awareness, but assume we'd notice bugs (and aren't in a great rush for new features)
     labels:
       - "Dependencies"
+    assignees:
+      - "MizouziE"


### PR DESCRIPTION
Ensures they're not forgotten , happy to add us all tbh.. thoughts?

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#assignees--