### PR TITLE
Exclude `pint.json` from export 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 /tests                  export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
-/.pint.json             export-ignore
+/pint.json              export-ignore
 /composer.lock          export-ignore
 /LICENSE                export-ignore
 /phpunit.xml.dist       export-ignore


### PR DESCRIPTION
This was using `.pint.json`, when it's `pint.json`.