### PR TITLE
Dependabot single grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,15 @@ version: 2
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 updates:
   - package-ecosystem: "composer"
-    open-pull-requests-limit: 1
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      composer:
+        patterns:
+          - "*"
     labels:
       - "Dependencies"
     assignees:
@@ -20,6 +23,10 @@ updates:
       interval: "monthly" # Enough for awareness, but assume we'd notice bugs (and aren't in a great rush for new features)
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "Dependencies"
     assignees:

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -27,7 +27,7 @@ jobs:
         image: [php-cli]
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,11 +25,11 @@ jobs:
         php-version:
           - '8.4'
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
@@ -37,7 +37,7 @@ jobs:
 
       - name: Restore Composer dependencies
         id: composer-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
I did not like seeing 4 separate PRs for action updates, so I will close all of those and let dependabot handle a bulk update.

Also addressed the sem-ver issue that zizmor has now, similar to the issue we saw yesterday.